### PR TITLE
1.21.4 Fix Crash when using new keybinding in KeybindsScreen

### DIFF
--- a/src/main/java/com/theendercore/escapescreen/mixins/KeybindsScreenMixin.java
+++ b/src/main/java/com/theendercore/escapescreen/mixins/KeybindsScreenMixin.java
@@ -40,9 +40,9 @@ public class KeybindsScreenMixin extends GameOptionsScreen {
     public void keyPressed(int keyCode, int scanCode, int modifiers, CallbackInfoReturnable<Boolean> cir) {
         if (this.selectedKeyBinding != null) {
             if (newEscKey.matchesKey(keyCode, scanCode)) {
-                this.gameOptions.setKeyCode(this.selectedKeyBinding, InputUtil.UNKNOWN_KEY);
+                this.selectedKeyBinding.setBoundKey(InputUtil.UNKNOWN_KEY);
             } else {
-                this.gameOptions.setKeyCode(this.selectedKeyBinding, InputUtil.fromKeyCode(keyCode, scanCode));
+                this.selectedKeyBinding.setBoundKey(InputUtil.fromKeyCode(keyCode, scanCode));
             }
             this.selectedKeyBinding = null;
             this.lastKeyCodeUpdateTime = Util.getMeasuringTimeMs();


### PR DESCRIPTION
This fixes a crash that appears in 1.21.4 when trying to clear a keybinding using the new escape keybinding